### PR TITLE
Fix lifecycle hook usage & Add support for absWorkingDir

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "esbuild-plugin-shelljs",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "esbuild-plugin-shelljs",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "ISC",
       "devDependencies": {
         "@types/node": "^20.14.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "esbuild-plugin-shelljs",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Patch at build-time the shelljs package to make it compatible with esbuild",
   "main": "build/index.js",
   "scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,19 +1,37 @@
-import { Plugin, PluginBuild } from 'esbuild';
+import { Plugin } from 'esbuild';
 import shell from 'shelljs';
 
 const name = 'esbuild-plugin-shelljs';
 
-
 export const shellJsPlugin: Plugin = {
     name: 'shelljs',
 
-    setup(build: PluginBuild) {
-        build.onStart(() => {
-            shell.exec(`npx patch-package --patch-dir node_modules/${name}/patches`);
-        });
+    setup(build) {
+        function getCdCommand(): string | null {
+            if (build.initialOptions.absWorkingDir) {
+                return `cd ${build.initialOptions.absWorkingDir}`;
+            }
+            return null;
+        }
 
-        build.onEnd(() => {
-            shell.exec(`npx patch-package --reverse --patch-dir node_modules/${name}/patches`);
+        function getPatchCommand(reverse?: boolean): string {
+            let command = `npx patch-package --patch-dir node_modules/${name}/patches`;
+            if (reverse) {
+                command += ' --reverse';
+            }
+            return command;
+        }
+
+        function getCommand(reverse?: boolean): string {
+            return [getCdCommand(), getPatchCommand(reverse)].filter(Boolean).join(' && ');
+        }
+
+        // Patch on plugin setup
+        shell.exec(getCommand());
+
+        // Unpatch on build end
+        build.onDispose(() => {
+            shell.exec(getCommand(true));
         });
     },
 };


### PR DESCRIPTION
- For successive builds, we should only patch on setup and reverse on dispose
- Add support for `absWorkingDir` to patch a sub-folder package.json